### PR TITLE
Adding CODEOWNERS file with growth-platform as default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ezcater/growth-platform


### PR DESCRIPTION
No CODEOWNERS file was present, so I've added one with Growth Platform as the default owner.