### PR TITLE
Add deprecation notice to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Deprecated
+
+This project is considered deprecated and is no longer receiving updates. Please use the
+[mail_allowlist](https://github.com/brightin/mail_allowlist) gem directly.
+
 # MailAllowed
 
 This gem is a renamed fork of an [existing gem](https://github.com/brightin/mail_whitelist).


### PR DESCRIPTION
Like the title says. The gem hasn't had any changes since 2020 (excluding commits adding security tooling). The following 4 repos are using this gem. I will notify them about it.

<img width="973" alt="Screenshot 2024-01-11 at 9 24 46 AM" src="https://github.com/ezcater/mail_allowed/assets/45184220/b2338ceb-ca5f-4ce6-b870-06533178ef0c">
